### PR TITLE
fix: Update MinIO and MinIO client image names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
     <<: *service_default
     container_name: minio
     hostname: minio
-    image: "${image_minio_name:-quay.io/minio/minio}:\
+    image: "${image_minio_name:-minio/minio}:\
       ${image_minio_version:-latest}"
     command:
       - server
@@ -296,7 +296,7 @@ services:
     hostname: minio-client
     depends_on:
       - minio  # start after the server
-    image: "${image_mc_name:-bitnami/minio-client}:\
+    image: "${image_mc_name:-minio/mc}:\
       ${image_mc_version:-latest}"
     # Run with custom entrypoint that sets the alias "minio" with admin
     # credentials, ensures that the "varfish" user and "varfish-server"


### PR DESCRIPTION
Minio started to put images behind paywalls and offers only latest images for free

<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default container images for Docker-based object storage services. MinIO server now defaults to minio/minio (replacing quay.io/minio/minio) and MinIO client to minio/mc (replacing bitnami/minio-client).
  - No changes to commands, environment variables, ports, or volumes; functionality and startup behavior remain unchanged.
  - Existing user overrides via environment or compose overrides continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->